### PR TITLE
Include HTTP StatusCode in APIError - fixes #42

### DIFF
--- a/aws/error.go
+++ b/aws/error.go
@@ -2,12 +2,13 @@ package aws
 
 // An APIError is an error returned by an AWS API.
 type APIError struct {
-	Type      string
-	Code      string
-	Message   string
-	RequestID string
-	HostID    string
-	Specifics map[string]string
+	StatusCode int // HTTP status code e.g. 200
+	Type       string
+	Code       string
+	Message    string
+	RequestID  string
+	HostID     string
+	Specifics  map[string]string
 }
 
 func (e APIError) Error() string {


### PR DESCRIPTION
Check for zero length responses and return just an APIError with
StatusCode - these are returned when an operation doesn't return
"special errors".