### PR TITLE
Url escape path components the way AWS expects - fixes #45

### DIFF
--- a/aws/rest.go
+++ b/aws/rest.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 // RestClient is the underlying client for REST-JSON and REST-XML APIs.
@@ -17,9 +19,45 @@ type RestClient struct {
 	APIVersion string
 }
 
+// Whether the byte value can be sent without escaping in AWS URLs
+var noEscape [256]bool
+
+// Initialise noEscape
+func init() {
+	for i := range noEscape {
+		// Amazon expects every character except these escaped
+		noEscape[i] = (i >= 'A' && i <= 'Z') ||
+			(i >= 'a' && i <= 'z') ||
+			(i >= '0' && i <= '9') ||
+			i == '-' ||
+			i == '.' ||
+			i == '/' ||
+			i == ':' ||
+			i == '_' ||
+			i == '~'
+	}
+}
+
+// EscapePath escapes part of a URL path in Amazon style
+func EscapePath(path string) string {
+	var buf bytes.Buffer
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if noEscape[c] {
+			buf.WriteByte(c)
+		} else {
+			buf.WriteByte('%')
+			buf.WriteString(strings.ToUpper(strconv.FormatUint(uint64(c), 16)))
+		}
+	}
+	return buf.String()
+}
+
 // Do sends an HTTP request and returns an HTTP response, following policy
 // (e.g. redirects, cookies, auth) as configured on the client.
 func (c *RestClient) Do(req *http.Request) (*http.Response, error) {
+	// Set the form for the URL
+	req.URL.Opaque = EscapePath(req.URL.Path)
 	req.Header.Set("User-Agent", "aws-go")
 	if err := c.Context.sign(req); err != nil {
 		return nil, err

--- a/aws/rest_test.go
+++ b/aws/rest_test.go
@@ -193,3 +193,23 @@ func TestRestRequestJSONError(t *testing.T) {
 		t.Errorf("Unknown error returned: %#v", err)
 	}
 }
+
+func TestEscapePath(t *testing.T) {
+	for _, x := range []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"ABCDEFGHIJKLMNOPQRTSUVWXYZ", "ABCDEFGHIJKLMNOPQRTSUVWXYZ"},
+		{"abcdefghijklmnopqrtsuvwxyz", "abcdefghijklmnopqrtsuvwxyz"},
+		{"0123456789", "0123456789"},
+		{"_-~./:", "_-~./:"},
+		{"test? file", "test%3F%20file"},
+		{`hello? sausage/êé/Hello, 世界/ " ' @ < > & ?/z.txt`, "hello%3F%20sausage/%C3%AA%C3%A9/Hello%2C%20%E4%B8%96%E7%95%8C/%20%22%20%27%20%40%20%3C%20%3E%20%26%20%3F/z.txt"},
+	} {
+		got := aws.EscapePath(x.in)
+		if got != x.want {
+			t.Errorf("EscapePath(%q) got %q, want %v", x.in, got, x.want)
+		}
+	}
+}

--- a/gen/cloudfront/cloudfront.go
+++ b/gen/cloudfront/cloudfront.go
@@ -199,8 +199,8 @@ func (c *CloudFront) CreateInvalidation(req *CreateInvalidationRequest) (resp *C
 	uri := c.client.Endpoint + "/2014-10-21/distribution/{DistributionId}/invalidation"
 
 	if req.DistributionID != nil {
-		uri = strings.Replace(uri, "{"+"DistributionId"+"}", *req.DistributionID, -1)
-		uri = strings.Replace(uri, "{"+"DistributionId+"+"}", *req.DistributionID, -1)
+		uri = strings.Replace(uri, "{"+"DistributionId"+"}", aws.EscapePath(*req.DistributionID), -1)
+		uri = strings.Replace(uri, "{"+"DistributionId+"+"}", aws.EscapePath(*req.DistributionID), -1)
 	}
 
 	q := url.Values{}
@@ -311,8 +311,8 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentity(req *DeleteCloudFrontO
 	uri := c.client.Endpoint + "/2014-10-21/origin-access-identity/cloudfront/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -354,8 +354,8 @@ func (c *CloudFront) DeleteDistribution(req *DeleteDistributionRequest) (err err
 	uri := c.client.Endpoint + "/2014-10-21/distribution/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -397,8 +397,8 @@ func (c *CloudFront) DeleteStreamingDistribution(req *DeleteStreamingDistributio
 	uri := c.client.Endpoint + "/2014-10-21/streaming-distribution/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -441,8 +441,8 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentity(req *GetCloudFrontOriginA
 	uri := c.client.Endpoint + "/2014-10-21/origin-access-identity/cloudfront/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -491,8 +491,8 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfig(req *GetCloudFrontO
 	uri := c.client.Endpoint + "/2014-10-21/origin-access-identity/cloudfront/{Id}/config"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -540,8 +540,8 @@ func (c *CloudFront) GetDistribution(req *GetDistributionRequest) (resp *GetDist
 	uri := c.client.Endpoint + "/2014-10-21/distribution/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -590,8 +590,8 @@ func (c *CloudFront) GetDistributionConfig(req *GetDistributionConfigRequest) (r
 	uri := c.client.Endpoint + "/2014-10-21/distribution/{Id}/config"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -639,13 +639,13 @@ func (c *CloudFront) GetInvalidation(req *GetInvalidationRequest) (resp *GetInva
 	uri := c.client.Endpoint + "/2014-10-21/distribution/{DistributionId}/invalidation/{Id}"
 
 	if req.DistributionID != nil {
-		uri = strings.Replace(uri, "{"+"DistributionId"+"}", *req.DistributionID, -1)
-		uri = strings.Replace(uri, "{"+"DistributionId+"+"}", *req.DistributionID, -1)
+		uri = strings.Replace(uri, "{"+"DistributionId"+"}", aws.EscapePath(*req.DistributionID), -1)
+		uri = strings.Replace(uri, "{"+"DistributionId+"+"}", aws.EscapePath(*req.DistributionID), -1)
 	}
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -688,8 +688,8 @@ func (c *CloudFront) GetStreamingDistribution(req *GetStreamingDistributionReque
 	uri := c.client.Endpoint + "/2014-10-21/streaming-distribution/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -738,8 +738,8 @@ func (c *CloudFront) GetStreamingDistributionConfig(req *GetStreamingDistributio
 	uri := c.client.Endpoint + "/2014-10-21/streaming-distribution/{Id}/config"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -879,8 +879,8 @@ func (c *CloudFront) ListInvalidations(req *ListInvalidationsRequest) (resp *Lis
 	uri := c.client.Endpoint + "/2014-10-21/distribution/{DistributionId}/invalidation"
 
 	if req.DistributionID != nil {
-		uri = strings.Replace(uri, "{"+"DistributionId"+"}", *req.DistributionID, -1)
-		uri = strings.Replace(uri, "{"+"DistributionId+"+"}", *req.DistributionID, -1)
+		uri = strings.Replace(uri, "{"+"DistributionId"+"}", aws.EscapePath(*req.DistributionID), -1)
+		uri = strings.Replace(uri, "{"+"DistributionId+"+"}", aws.EscapePath(*req.DistributionID), -1)
 	}
 
 	q := url.Values{}
@@ -989,8 +989,8 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentity(req *UpdateCloudFrontO
 	uri := c.client.Endpoint + "/2014-10-21/origin-access-identity/cloudfront/{Id}/config"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -1055,8 +1055,8 @@ func (c *CloudFront) UpdateDistribution(req *UpdateDistributionRequest) (resp *U
 	uri := c.client.Endpoint + "/2014-10-21/distribution/{Id}/config"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -1121,8 +1121,8 @@ func (c *CloudFront) UpdateStreamingDistribution(req *UpdateStreamingDistributio
 	uri := c.client.Endpoint + "/2014-10-21/streaming-distribution/{Id}/config"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}

--- a/gen/cognito/sync/sync.go
+++ b/gen/cognito/sync/sync.go
@@ -63,18 +63,18 @@ func (c *CognitoSync) DeleteDataset(req *DeleteDatasetRequest) (resp *DeleteData
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}"
 
 	if req.DatasetName != nil {
-		uri = strings.Replace(uri, "{"+"DatasetName"+"}", *req.DatasetName, -1)
-		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", *req.DatasetName, -1)
+		uri = strings.Replace(uri, "{"+"DatasetName"+"}", aws.EscapePath(*req.DatasetName), -1)
+		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", aws.EscapePath(*req.DatasetName), -1)
 	}
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -121,18 +121,18 @@ func (c *CognitoSync) DescribeDataset(req *DescribeDatasetRequest) (resp *Descri
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}"
 
 	if req.DatasetName != nil {
-		uri = strings.Replace(uri, "{"+"DatasetName"+"}", *req.DatasetName, -1)
-		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", *req.DatasetName, -1)
+		uri = strings.Replace(uri, "{"+"DatasetName"+"}", aws.EscapePath(*req.DatasetName), -1)
+		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", aws.EscapePath(*req.DatasetName), -1)
 	}
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -176,8 +176,8 @@ func (c *CognitoSync) DescribeIdentityPoolUsage(req *DescribeIdentityPoolUsageRe
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}"
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -221,13 +221,13 @@ func (c *CognitoSync) DescribeIdentityUsage(req *DescribeIdentityUsageRequest) (
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}"
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -271,8 +271,8 @@ func (c *CognitoSync) GetIdentityPoolConfiguration(req *GetIdentityPoolConfigura
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/configuration"
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -319,13 +319,13 @@ func (c *CognitoSync) ListDatasets(req *ListDatasetsRequest) (resp *ListDatasets
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets"
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -429,18 +429,18 @@ func (c *CognitoSync) ListRecords(req *ListRecordsRequest) (resp *ListRecordsRes
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/records"
 
 	if req.DatasetName != nil {
-		uri = strings.Replace(uri, "{"+"DatasetName"+"}", *req.DatasetName, -1)
-		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", *req.DatasetName, -1)
+		uri = strings.Replace(uri, "{"+"DatasetName"+"}", aws.EscapePath(*req.DatasetName), -1)
+		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", aws.EscapePath(*req.DatasetName), -1)
 	}
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -499,13 +499,13 @@ func (c *CognitoSync) RegisterDevice(req *RegisterDeviceRequest) (resp *Register
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identity/{IdentityId}/device"
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -548,8 +548,8 @@ func (c *CognitoSync) SetIdentityPoolConfiguration(req *SetIdentityPoolConfigura
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/configuration"
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -593,23 +593,23 @@ func (c *CognitoSync) SubscribeToDataset(req *SubscribeToDatasetRequest) (resp *
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/subscriptions/{DeviceId}"
 
 	if req.DatasetName != nil {
-		uri = strings.Replace(uri, "{"+"DatasetName"+"}", *req.DatasetName, -1)
-		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", *req.DatasetName, -1)
+		uri = strings.Replace(uri, "{"+"DatasetName"+"}", aws.EscapePath(*req.DatasetName), -1)
+		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", aws.EscapePath(*req.DatasetName), -1)
 	}
 
 	if req.DeviceID != nil {
-		uri = strings.Replace(uri, "{"+"DeviceId"+"}", *req.DeviceID, -1)
-		uri = strings.Replace(uri, "{"+"DeviceId+"+"}", *req.DeviceID, -1)
+		uri = strings.Replace(uri, "{"+"DeviceId"+"}", aws.EscapePath(*req.DeviceID), -1)
+		uri = strings.Replace(uri, "{"+"DeviceId+"+"}", aws.EscapePath(*req.DeviceID), -1)
 	}
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -653,23 +653,23 @@ func (c *CognitoSync) UnsubscribeFromDataset(req *UnsubscribeFromDatasetRequest)
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/subscriptions/{DeviceId}"
 
 	if req.DatasetName != nil {
-		uri = strings.Replace(uri, "{"+"DatasetName"+"}", *req.DatasetName, -1)
-		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", *req.DatasetName, -1)
+		uri = strings.Replace(uri, "{"+"DatasetName"+"}", aws.EscapePath(*req.DatasetName), -1)
+		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", aws.EscapePath(*req.DatasetName), -1)
 	}
 
 	if req.DeviceID != nil {
-		uri = strings.Replace(uri, "{"+"DeviceId"+"}", *req.DeviceID, -1)
-		uri = strings.Replace(uri, "{"+"DeviceId+"+"}", *req.DeviceID, -1)
+		uri = strings.Replace(uri, "{"+"DeviceId"+"}", aws.EscapePath(*req.DeviceID), -1)
+		uri = strings.Replace(uri, "{"+"DeviceId+"+"}", aws.EscapePath(*req.DeviceID), -1)
 	}
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}
@@ -717,18 +717,18 @@ func (c *CognitoSync) UpdateRecords(req *UpdateRecordsRequest) (resp *UpdateReco
 	uri := c.client.Endpoint + "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}"
 
 	if req.DatasetName != nil {
-		uri = strings.Replace(uri, "{"+"DatasetName"+"}", *req.DatasetName, -1)
-		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", *req.DatasetName, -1)
+		uri = strings.Replace(uri, "{"+"DatasetName"+"}", aws.EscapePath(*req.DatasetName), -1)
+		uri = strings.Replace(uri, "{"+"DatasetName+"+"}", aws.EscapePath(*req.DatasetName), -1)
 	}
 
 	if req.IdentityID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityId"+"}", *req.IdentityID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", *req.IdentityID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityId"+"}", aws.EscapePath(*req.IdentityID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityId+"+"}", aws.EscapePath(*req.IdentityID), -1)
 	}
 
 	if req.IdentityPoolID != nil {
-		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", *req.IdentityPoolID, -1)
-		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", *req.IdentityPoolID, -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
+		uri = strings.Replace(uri, "{"+"IdentityPoolId+"+"}", aws.EscapePath(*req.IdentityPoolID), -1)
 	}
 
 	q := url.Values{}

--- a/gen/elastictranscoder/elastictranscoder.go
+++ b/gen/elastictranscoder/elastictranscoder.go
@@ -63,8 +63,8 @@ func (c *ElasticTranscoder) CancelJob(req *CancelJobRequest) (resp *CancelJobRes
 	uri := c.client.Endpoint + "/2012-09-25/jobs/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -247,8 +247,8 @@ func (c *ElasticTranscoder) DeletePipeline(req *DeletePipelineRequest) (resp *De
 	uri := c.client.Endpoint + "/2012-09-25/pipelines/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -293,8 +293,8 @@ func (c *ElasticTranscoder) DeletePreset(req *DeletePresetRequest) (resp *Delete
 	uri := c.client.Endpoint + "/2012-09-25/presets/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -340,8 +340,8 @@ func (c *ElasticTranscoder) ListJobsByPipeline(req *ListJobsByPipelineRequest) (
 	uri := c.client.Endpoint + "/2012-09-25/jobsByPipeline/{PipelineId}"
 
 	if req.PipelineID != nil {
-		uri = strings.Replace(uri, "{"+"PipelineId"+"}", *req.PipelineID, -1)
-		uri = strings.Replace(uri, "{"+"PipelineId+"+"}", *req.PipelineID, -1)
+		uri = strings.Replace(uri, "{"+"PipelineId"+"}", aws.EscapePath(*req.PipelineID), -1)
+		uri = strings.Replace(uri, "{"+"PipelineId+"+"}", aws.EscapePath(*req.PipelineID), -1)
 	}
 
 	q := url.Values{}
@@ -394,8 +394,8 @@ func (c *ElasticTranscoder) ListJobsByStatus(req *ListJobsByStatusRequest) (resp
 	uri := c.client.Endpoint + "/2012-09-25/jobsByStatus/{Status}"
 
 	if req.Status != nil {
-		uri = strings.Replace(uri, "{"+"Status"+"}", *req.Status, -1)
-		uri = strings.Replace(uri, "{"+"Status+"+"}", *req.Status, -1)
+		uri = strings.Replace(uri, "{"+"Status"+"}", aws.EscapePath(*req.Status), -1)
+		uri = strings.Replace(uri, "{"+"Status+"+"}", aws.EscapePath(*req.Status), -1)
 	}
 
 	q := url.Values{}
@@ -543,8 +543,8 @@ func (c *ElasticTranscoder) ReadJob(req *ReadJobRequest) (resp *ReadJobResponse,
 	uri := c.client.Endpoint + "/2012-09-25/jobs/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -588,8 +588,8 @@ func (c *ElasticTranscoder) ReadPipeline(req *ReadPipelineRequest) (resp *ReadPi
 	uri := c.client.Endpoint + "/2012-09-25/pipelines/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -633,8 +633,8 @@ func (c *ElasticTranscoder) ReadPreset(req *ReadPresetRequest) (resp *ReadPreset
 	uri := c.client.Endpoint + "/2012-09-25/presets/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -726,8 +726,8 @@ func (c *ElasticTranscoder) UpdatePipeline(req *UpdatePipelineRequest) (resp *Up
 	uri := c.client.Endpoint + "/2012-09-25/pipelines/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -774,8 +774,8 @@ func (c *ElasticTranscoder) UpdatePipelineNotifications(req *UpdatePipelineNotif
 	uri := c.client.Endpoint + "/2012-09-25/pipelines/{Id}/notifications"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -824,8 +824,8 @@ func (c *ElasticTranscoder) UpdatePipelineStatus(req *UpdatePipelineStatusReques
 	uri := c.client.Endpoint + "/2012-09-25/pipelines/{Id}/status"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}

--- a/gen/lambda/lambda.go
+++ b/gen/lambda/lambda.go
@@ -111,8 +111,8 @@ func (c *Lambda) DeleteFunction(req *DeleteFunctionRequest) (err error) {
 	uri := c.client.Endpoint + "/2014-11-13/functions/{FunctionName}"
 
 	if req.FunctionName != nil {
-		uri = strings.Replace(uri, "{"+"FunctionName"+"}", *req.FunctionName, -1)
-		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", *req.FunctionName, -1)
+		uri = strings.Replace(uri, "{"+"FunctionName"+"}", aws.EscapePath(*req.FunctionName), -1)
+		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", aws.EscapePath(*req.FunctionName), -1)
 	}
 
 	q := url.Values{}
@@ -152,8 +152,8 @@ func (c *Lambda) GetEventSource(req *GetEventSourceRequest) (resp *EventSourceCo
 	uri := c.client.Endpoint + "/2014-11-13/event-source-mappings/{UUID}"
 
 	if req.UUID != nil {
-		uri = strings.Replace(uri, "{"+"UUID"+"}", *req.UUID, -1)
-		uri = strings.Replace(uri, "{"+"UUID+"+"}", *req.UUID, -1)
+		uri = strings.Replace(uri, "{"+"UUID"+"}", aws.EscapePath(*req.UUID), -1)
+		uri = strings.Replace(uri, "{"+"UUID+"+"}", aws.EscapePath(*req.UUID), -1)
 	}
 
 	q := url.Values{}
@@ -201,8 +201,8 @@ func (c *Lambda) GetFunction(req *GetFunctionRequest) (resp *GetFunctionResponse
 	uri := c.client.Endpoint + "/2014-11-13/functions/{FunctionName}"
 
 	if req.FunctionName != nil {
-		uri = strings.Replace(uri, "{"+"FunctionName"+"}", *req.FunctionName, -1)
-		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", *req.FunctionName, -1)
+		uri = strings.Replace(uri, "{"+"FunctionName"+"}", aws.EscapePath(*req.FunctionName), -1)
+		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", aws.EscapePath(*req.FunctionName), -1)
 	}
 
 	q := url.Values{}
@@ -248,8 +248,8 @@ func (c *Lambda) GetFunctionConfiguration(req *GetFunctionConfigurationRequest) 
 	uri := c.client.Endpoint + "/2014-11-13/functions/{FunctionName}/configuration"
 
 	if req.FunctionName != nil {
-		uri = strings.Replace(uri, "{"+"FunctionName"+"}", *req.FunctionName, -1)
-		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", *req.FunctionName, -1)
+		uri = strings.Replace(uri, "{"+"FunctionName"+"}", aws.EscapePath(*req.FunctionName), -1)
+		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", aws.EscapePath(*req.FunctionName), -1)
 	}
 
 	q := url.Values{}
@@ -303,8 +303,8 @@ func (c *Lambda) InvokeAsync(req *InvokeAsyncRequest) (resp *InvokeAsyncResponse
 	uri := c.client.Endpoint + "/2014-11-13/functions/{FunctionName}/invoke-async/"
 
 	if req.FunctionName != nil {
-		uri = strings.Replace(uri, "{"+"FunctionName"+"}", *req.FunctionName, -1)
-		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", *req.FunctionName, -1)
+		uri = strings.Replace(uri, "{"+"FunctionName"+"}", aws.EscapePath(*req.FunctionName), -1)
+		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", aws.EscapePath(*req.FunctionName), -1)
 	}
 
 	q := url.Values{}
@@ -461,8 +461,8 @@ func (c *Lambda) RemoveEventSource(req *RemoveEventSourceRequest) (err error) {
 	uri := c.client.Endpoint + "/2014-11-13/event-source-mappings/{UUID}"
 
 	if req.UUID != nil {
-		uri = strings.Replace(uri, "{"+"UUID"+"}", *req.UUID, -1)
-		uri = strings.Replace(uri, "{"+"UUID+"+"}", *req.UUID, -1)
+		uri = strings.Replace(uri, "{"+"UUID"+"}", aws.EscapePath(*req.UUID), -1)
+		uri = strings.Replace(uri, "{"+"UUID+"+"}", aws.EscapePath(*req.UUID), -1)
 	}
 
 	q := url.Values{}
@@ -505,8 +505,8 @@ func (c *Lambda) UpdateFunctionConfiguration(req *UpdateFunctionConfigurationReq
 	uri := c.client.Endpoint + "/2014-11-13/functions/{FunctionName}/configuration"
 
 	if req.FunctionName != nil {
-		uri = strings.Replace(uri, "{"+"FunctionName"+"}", *req.FunctionName, -1)
-		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", *req.FunctionName, -1)
+		uri = strings.Replace(uri, "{"+"FunctionName"+"}", aws.EscapePath(*req.FunctionName), -1)
+		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", aws.EscapePath(*req.FunctionName), -1)
 	}
 
 	q := url.Values{}
@@ -581,8 +581,8 @@ func (c *Lambda) UploadFunction(req *UploadFunctionRequest) (resp *FunctionConfi
 	uri := c.client.Endpoint + "/2014-11-13/functions/{FunctionName}"
 
 	if req.FunctionName != nil {
-		uri = strings.Replace(uri, "{"+"FunctionName"+"}", *req.FunctionName, -1)
-		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", *req.FunctionName, -1)
+		uri = strings.Replace(uri, "{"+"FunctionName"+"}", aws.EscapePath(*req.FunctionName), -1)
+		uri = strings.Replace(uri, "{"+"FunctionName+"+"}", aws.EscapePath(*req.FunctionName), -1)
 	}
 
 	q := url.Values{}

--- a/gen/route53/route53.go
+++ b/gen/route53/route53.go
@@ -79,8 +79,8 @@ func (c *Route53) AssociateVPCWithHostedZone(req *AssociateVPCWithHostedZoneRequ
 	uri := c.client.Endpoint + "/2013-04-01/hostedzone/{Id}/associatevpc"
 
 	if req.HostedZoneID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.HostedZoneID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.HostedZoneID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.HostedZoneID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.HostedZoneID), -1)
 	}
 
 	q := url.Values{}
@@ -153,8 +153,8 @@ func (c *Route53) ChangeResourceRecordSets(req *ChangeResourceRecordSetsRequest)
 	uri := c.client.Endpoint + "/2013-04-01/hostedzone/{Id}/rrset/"
 
 	if req.HostedZoneID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.HostedZoneID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.HostedZoneID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.HostedZoneID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.HostedZoneID), -1)
 	}
 
 	q := url.Values{}
@@ -207,13 +207,13 @@ func (c *Route53) ChangeTagsForResource(req *ChangeTagsForResourceRequest) (resp
 	uri := c.client.Endpoint + "/2013-04-01/tags/{ResourceType}/{ResourceId}"
 
 	if req.ResourceID != nil {
-		uri = strings.Replace(uri, "{"+"ResourceId"+"}", *req.ResourceID, -1)
-		uri = strings.Replace(uri, "{"+"ResourceId+"+"}", *req.ResourceID, -1)
+		uri = strings.Replace(uri, "{"+"ResourceId"+"}", aws.EscapePath(*req.ResourceID), -1)
+		uri = strings.Replace(uri, "{"+"ResourceId+"+"}", aws.EscapePath(*req.ResourceID), -1)
 	}
 
 	if req.ResourceType != nil {
-		uri = strings.Replace(uri, "{"+"ResourceType"+"}", *req.ResourceType, -1)
-		uri = strings.Replace(uri, "{"+"ResourceType+"+"}", *req.ResourceType, -1)
+		uri = strings.Replace(uri, "{"+"ResourceType"+"}", aws.EscapePath(*req.ResourceType), -1)
+		uri = strings.Replace(uri, "{"+"ResourceType+"+"}", aws.EscapePath(*req.ResourceType), -1)
 	}
 
 	q := url.Values{}
@@ -456,8 +456,8 @@ func (c *Route53) DeleteHealthCheck(req *DeleteHealthCheckRequest) (resp *Delete
 	uri := c.client.Endpoint + "/2013-04-01/healthcheck/{HealthCheckId}"
 
 	if req.HealthCheckID != nil {
-		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", *req.HealthCheckID, -1)
-		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", *req.HealthCheckID, -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", aws.EscapePath(*req.HealthCheckID), -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", aws.EscapePath(*req.HealthCheckID), -1)
 	}
 
 	q := url.Values{}
@@ -509,8 +509,8 @@ func (c *Route53) DeleteHostedZone(req *DeleteHostedZoneRequest) (resp *DeleteHo
 	uri := c.client.Endpoint + "/2013-04-01/hostedzone/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -559,8 +559,8 @@ func (c *Route53) DeleteReusableDelegationSet(req *DeleteReusableDelegationSetRe
 	uri := c.client.Endpoint + "/2013-04-01/delegationset/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -621,8 +621,8 @@ func (c *Route53) DisassociateVPCFromHostedZone(req *DisassociateVPCFromHostedZo
 	uri := c.client.Endpoint + "/2013-04-01/hostedzone/{Id}/disassociatevpc"
 
 	if req.HostedZoneID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.HostedZoneID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.HostedZoneID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.HostedZoneID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.HostedZoneID), -1)
 	}
 
 	q := url.Values{}
@@ -668,8 +668,8 @@ func (c *Route53) GetChange(req *GetChangeRequest) (resp *GetChangeResponse, err
 	uri := c.client.Endpoint + "/2013-04-01/change/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -806,8 +806,8 @@ func (c *Route53) GetHealthCheck(req *GetHealthCheckRequest) (resp *GetHealthChe
 	uri := c.client.Endpoint + "/2013-04-01/healthcheck/{HealthCheckId}"
 
 	if req.HealthCheckID != nil {
-		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", *req.HealthCheckID, -1)
-		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", *req.HealthCheckID, -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", aws.EscapePath(*req.HealthCheckID), -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", aws.EscapePath(*req.HealthCheckID), -1)
 	}
 
 	q := url.Values{}
@@ -891,8 +891,8 @@ func (c *Route53) GetHealthCheckLastFailureReason(req *GetHealthCheckLastFailure
 	uri := c.client.Endpoint + "/2013-04-01/healthcheck/{HealthCheckId}/lastfailurereason"
 
 	if req.HealthCheckID != nil {
-		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", *req.HealthCheckID, -1)
-		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", *req.HealthCheckID, -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", aws.EscapePath(*req.HealthCheckID), -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", aws.EscapePath(*req.HealthCheckID), -1)
 	}
 
 	q := url.Values{}
@@ -936,8 +936,8 @@ func (c *Route53) GetHealthCheckStatus(req *GetHealthCheckStatusRequest) (resp *
 	uri := c.client.Endpoint + "/2013-04-01/healthcheck/{HealthCheckId}/status"
 
 	if req.HealthCheckID != nil {
-		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", *req.HealthCheckID, -1)
-		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", *req.HealthCheckID, -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", aws.EscapePath(*req.HealthCheckID), -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", aws.EscapePath(*req.HealthCheckID), -1)
 	}
 
 	q := url.Values{}
@@ -982,8 +982,8 @@ func (c *Route53) GetHostedZone(req *GetHostedZoneRequest) (resp *GetHostedZoneR
 	uri := c.client.Endpoint + "/2013-04-01/hostedzone/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -1026,8 +1026,8 @@ func (c *Route53) GetReusableDelegationSet(req *GetReusableDelegationSetRequest)
 	uri := c.client.Endpoint + "/2013-04-01/delegationset/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}
@@ -1279,8 +1279,8 @@ func (c *Route53) ListResourceRecordSets(req *ListResourceRecordSetsRequest) (re
 	uri := c.client.Endpoint + "/2013-04-01/hostedzone/{Id}/rrset"
 
 	if req.HostedZoneID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.HostedZoneID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.HostedZoneID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.HostedZoneID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.HostedZoneID), -1)
 	}
 
 	q := url.Values{}
@@ -1393,13 +1393,13 @@ func (c *Route53) ListTagsForResource(req *ListTagsForResourceRequest) (resp *Li
 	uri := c.client.Endpoint + "/2013-04-01/tags/{ResourceType}/{ResourceId}"
 
 	if req.ResourceID != nil {
-		uri = strings.Replace(uri, "{"+"ResourceId"+"}", *req.ResourceID, -1)
-		uri = strings.Replace(uri, "{"+"ResourceId+"+"}", *req.ResourceID, -1)
+		uri = strings.Replace(uri, "{"+"ResourceId"+"}", aws.EscapePath(*req.ResourceID), -1)
+		uri = strings.Replace(uri, "{"+"ResourceId+"+"}", aws.EscapePath(*req.ResourceID), -1)
 	}
 
 	if req.ResourceType != nil {
-		uri = strings.Replace(uri, "{"+"ResourceType"+"}", *req.ResourceType, -1)
-		uri = strings.Replace(uri, "{"+"ResourceType+"+"}", *req.ResourceType, -1)
+		uri = strings.Replace(uri, "{"+"ResourceType"+"}", aws.EscapePath(*req.ResourceType), -1)
+		uri = strings.Replace(uri, "{"+"ResourceType+"+"}", aws.EscapePath(*req.ResourceType), -1)
 	}
 
 	q := url.Values{}
@@ -1452,8 +1452,8 @@ func (c *Route53) ListTagsForResources(req *ListTagsForResourcesRequest) (resp *
 	uri := c.client.Endpoint + "/2013-04-01/tags/{ResourceType}"
 
 	if req.ResourceType != nil {
-		uri = strings.Replace(uri, "{"+"ResourceType"+"}", *req.ResourceType, -1)
-		uri = strings.Replace(uri, "{"+"ResourceType+"+"}", *req.ResourceType, -1)
+		uri = strings.Replace(uri, "{"+"ResourceType"+"}", aws.EscapePath(*req.ResourceType), -1)
+		uri = strings.Replace(uri, "{"+"ResourceType+"+"}", aws.EscapePath(*req.ResourceType), -1)
 	}
 
 	q := url.Values{}
@@ -1511,8 +1511,8 @@ func (c *Route53) UpdateHealthCheck(req *UpdateHealthCheckRequest) (resp *Update
 	uri := c.client.Endpoint + "/2013-04-01/healthcheck/{HealthCheckId}"
 
 	if req.HealthCheckID != nil {
-		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", *req.HealthCheckID, -1)
-		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", *req.HealthCheckID, -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId"+"}", aws.EscapePath(*req.HealthCheckID), -1)
+		uri = strings.Replace(uri, "{"+"HealthCheckId+"+"}", aws.EscapePath(*req.HealthCheckID), -1)
 	}
 
 	q := url.Values{}
@@ -1569,8 +1569,8 @@ func (c *Route53) UpdateHostedZoneComment(req *UpdateHostedZoneCommentRequest) (
 	uri := c.client.Endpoint + "/2013-04-01/hostedzone/{Id}"
 
 	if req.ID != nil {
-		uri = strings.Replace(uri, "{"+"Id"+"}", *req.ID, -1)
-		uri = strings.Replace(uri, "{"+"Id+"+"}", *req.ID, -1)
+		uri = strings.Replace(uri, "{"+"Id"+"}", aws.EscapePath(*req.ID), -1)
+		uri = strings.Replace(uri, "{"+"Id+"+"}", aws.EscapePath(*req.ID), -1)
 	}
 
 	q := url.Values{}

--- a/gen/s3/s3.go
+++ b/gen/s3/s3.go
@@ -62,13 +62,13 @@ func (c *S3) AbortMultipartUpload(req *AbortMultipartUploadRequest) (err error) 
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -124,13 +124,13 @@ func (c *S3) CompleteMultipartUpload(req *CompleteMultipartUploadRequest) (resp 
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -201,13 +201,13 @@ func (c *S3) CopyObject(req *CopyObjectRequest) (resp *CopyObjectOutput, err err
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -406,8 +406,8 @@ func (c *S3) CreateBucket(req *CreateBucketRequest) (resp *CreateBucketOutput, e
 	uri := c.client.Endpoint + "/{Bucket}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -484,13 +484,13 @@ func (c *S3) CreateMultipartUpload(req *CreateMultipartUploadRequest) (resp *Cre
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}?uploads"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -630,8 +630,8 @@ func (c *S3) DeleteBucket(req *DeleteBucketRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -670,8 +670,8 @@ func (c *S3) DeleteBucketCORS(req *DeleteBucketCORSRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?cors"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -710,8 +710,8 @@ func (c *S3) DeleteBucketLifecycle(req *DeleteBucketLifecycleRequest) (err error
 	uri := c.client.Endpoint + "/{Bucket}?lifecycle"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -749,8 +749,8 @@ func (c *S3) DeleteBucketPolicy(req *DeleteBucketPolicyRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?policy"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -788,8 +788,8 @@ func (c *S3) DeleteBucketTagging(req *DeleteBucketTaggingRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?tagging"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -828,8 +828,8 @@ func (c *S3) DeleteBucketWebsite(req *DeleteBucketWebsiteRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?website"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -869,13 +869,13 @@ func (c *S3) DeleteObject(req *DeleteObjectRequest) (resp *DeleteObjectOutput, e
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -956,8 +956,8 @@ func (c *S3) DeleteObjects(req *DeleteObjectsRequest) (resp *DeleteObjectsOutput
 	uri := c.client.Endpoint + "/{Bucket}?delete"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1003,8 +1003,8 @@ func (c *S3) GetBucketACL(req *GetBucketACLRequest) (resp *GetBucketACLOutput, e
 	uri := c.client.Endpoint + "/{Bucket}?acl"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1046,8 +1046,8 @@ func (c *S3) GetBucketCORS(req *GetBucketCORSRequest) (resp *GetBucketCORSOutput
 	uri := c.client.Endpoint + "/{Bucket}?cors"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1090,8 +1090,8 @@ func (c *S3) GetBucketLifecycle(req *GetBucketLifecycleRequest) (resp *GetBucket
 	uri := c.client.Endpoint + "/{Bucket}?lifecycle"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1133,8 +1133,8 @@ func (c *S3) GetBucketLocation(req *GetBucketLocationRequest) (resp *GetBucketLo
 	uri := c.client.Endpoint + "/{Bucket}?location"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1178,8 +1178,8 @@ func (c *S3) GetBucketLogging(req *GetBucketLoggingRequest) (resp *GetBucketLogg
 	uri := c.client.Endpoint + "/{Bucket}?logging"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1221,8 +1221,8 @@ func (c *S3) GetBucketNotification(req *GetBucketNotificationRequest) (resp *Get
 	uri := c.client.Endpoint + "/{Bucket}?notification"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1264,8 +1264,8 @@ func (c *S3) GetBucketPolicy(req *GetBucketPolicyRequest) (resp *GetBucketPolicy
 	uri := c.client.Endpoint + "/{Bucket}?policy"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1308,8 +1308,8 @@ func (c *S3) GetBucketRequestPayment(req *GetBucketRequestPaymentRequest) (resp 
 	uri := c.client.Endpoint + "/{Bucket}?requestPayment"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1351,8 +1351,8 @@ func (c *S3) GetBucketTagging(req *GetBucketTaggingRequest) (resp *GetBucketTagg
 	uri := c.client.Endpoint + "/{Bucket}?tagging"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1394,8 +1394,8 @@ func (c *S3) GetBucketVersioning(req *GetBucketVersioningRequest) (resp *GetBuck
 	uri := c.client.Endpoint + "/{Bucket}?versioning"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1437,8 +1437,8 @@ func (c *S3) GetBucketWebsite(req *GetBucketWebsiteRequest) (resp *GetBucketWebs
 	uri := c.client.Endpoint + "/{Bucket}?website"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1480,13 +1480,13 @@ func (c *S3) GetObject(req *GetObjectRequest) (resp *GetObjectOutput, err error)
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -1738,13 +1738,13 @@ func (c *S3) GetObjectACL(req *GetObjectACLRequest) (resp *GetObjectACLOutput, e
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}?acl"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -1790,13 +1790,13 @@ func (c *S3) GetObjectTorrent(req *GetObjectTorrentRequest) (resp *GetObjectTorr
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}?torrent"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -1835,8 +1835,8 @@ func (c *S3) HeadBucket(req *HeadBucketRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -1877,13 +1877,13 @@ func (c *S3) HeadObject(req *HeadObjectRequest) (resp *HeadObjectOutput, err err
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -2154,8 +2154,8 @@ func (c *S3) ListMultipartUploads(req *ListMultipartUploadsRequest) (resp *ListM
 	uri := c.client.Endpoint + "/{Bucket}?uploads"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2222,8 +2222,8 @@ func (c *S3) ListObjectVersions(req *ListObjectVersionsRequest) (resp *ListObjec
 	uri := c.client.Endpoint + "/{Bucket}?versions"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2291,8 +2291,8 @@ func (c *S3) ListObjects(req *ListObjectsRequest) (resp *ListObjectsOutput, err 
 	uri := c.client.Endpoint + "/{Bucket}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2355,13 +2355,13 @@ func (c *S3) ListParts(req *ListPartsRequest) (resp *ListPartsOutput, err error)
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -2428,8 +2428,8 @@ func (c *S3) PutBucketACL(req *PutBucketACLRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?acl"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2508,8 +2508,8 @@ func (c *S3) PutBucketCORS(req *PutBucketCORSRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?cors"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2565,8 +2565,8 @@ func (c *S3) PutBucketLifecycle(req *PutBucketLifecycleRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?lifecycle"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2623,8 +2623,8 @@ func (c *S3) PutBucketLogging(req *PutBucketLoggingRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?logging"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2680,8 +2680,8 @@ func (c *S3) PutBucketNotification(req *PutBucketNotificationRequest) (err error
 	uri := c.client.Endpoint + "/{Bucket}?notification"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2732,8 +2732,8 @@ func (c *S3) PutBucketPolicy(req *PutBucketPolicyRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?policy"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2792,8 +2792,8 @@ func (c *S3) PutBucketRequestPayment(req *PutBucketRequestPaymentRequest) (err e
 	uri := c.client.Endpoint + "/{Bucket}?requestPayment"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2848,8 +2848,8 @@ func (c *S3) PutBucketTagging(req *PutBucketTaggingRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?tagging"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2905,8 +2905,8 @@ func (c *S3) PutBucketVersioning(req *PutBucketVersioningRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?versioning"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -2965,8 +2965,8 @@ func (c *S3) PutBucketWebsite(req *PutBucketWebsiteRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}?website"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	q := url.Values{}
@@ -3010,13 +3010,13 @@ func (c *S3) PutObject(req *PutObjectRequest) (resp *PutObjectOutput, err error)
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -3194,13 +3194,13 @@ func (c *S3) PutObjectACL(req *PutObjectACLRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}?acl"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -3279,13 +3279,13 @@ func (c *S3) RestoreObject(req *RestoreObjectRequest) (err error) {
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}?restore"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -3334,13 +3334,13 @@ func (c *S3) UploadPart(req *UploadPartRequest) (resp *UploadPartOutput, err err
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}
@@ -3441,13 +3441,13 @@ func (c *S3) UploadPartCopy(req *UploadPartCopyRequest) (resp *UploadPartCopyOut
 	uri := c.client.Endpoint + "/{Bucket}/{Key+}"
 
 	if req.Bucket != nil {
-		uri = strings.Replace(uri, "{"+"Bucket"+"}", *req.Bucket, -1)
-		uri = strings.Replace(uri, "{"+"Bucket+"+"}", *req.Bucket, -1)
+		uri = strings.Replace(uri, "{"+"Bucket"+"}", aws.EscapePath(*req.Bucket), -1)
+		uri = strings.Replace(uri, "{"+"Bucket+"+"}", aws.EscapePath(*req.Bucket), -1)
 	}
 
 	if req.Key != nil {
-		uri = strings.Replace(uri, "{"+"Key"+"}", *req.Key, -1)
-		uri = strings.Replace(uri, "{"+"Key+"+"}", *req.Key, -1)
+		uri = strings.Replace(uri, "{"+"Key"+"}", aws.EscapePath(*req.Key), -1)
+		uri = strings.Replace(uri, "{"+"Key+"+"}", aws.EscapePath(*req.Key), -1)
 	}
 
 	q := url.Values{}

--- a/model/templates.go
+++ b/model/templates.go
@@ -297,8 +297,8 @@ func restCommon(t *template.Template) (*template.Template, error) {
   {{ if eq $m.Location "uri" }}
 
   if req.{{ exportable $name }} != nil {
-    uri = strings.Replace(uri, "{"+"{{ $m.LocationName }}"+"}", *req.{{ exportable $name }}, -1)
-    uri = strings.Replace(uri, "{"+"{{ $m.LocationName }}+"+"}", *req.{{ exportable $name }}, -1)
+    uri = strings.Replace(uri, "{"+"{{ $m.LocationName }}"+"}", aws.EscapePath(*req.{{ exportable $name }}), -1)
+    uri = strings.Replace(uri, "{"+"{{ $m.LocationName }}+"+"}", aws.EscapePath(*req.{{ exportable $name }}), -1)
   }
 
   {{ end }}


### PR DESCRIPTION
We end up escaping each individual component to avoid interpretation
(eg to make sure '?' doesn't get interpreted as a start of query
string).  The URL parsing in the httpclient undoes this, but we re-do
it when making the request in RestClient.Do by setting URL.Opaque.