### PR TITLE
Implement xml.Unmarshaler for map

### DIFF
--- a/gen/autoscaling/autoscaling.go
+++ b/gen/autoscaling/autoscaling.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // AutoScaling is a client for Auto Scaling.
 type AutoScaling struct {
 	client *aws.QueryClient
@@ -1314,3 +1319,6 @@ type TerminateInstanceInAutoScalingGroupResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/cloudformation/cloudformation.go
+++ b/gen/cloudformation/cloudformation.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // CloudFormation is a client for AWS CloudFormation.
 type CloudFormation struct {
 	client *aws.QueryClient
@@ -667,3 +672,6 @@ type ValidateTemplateResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/cloudwatch/cloudwatch.go
+++ b/gen/cloudwatch/cloudwatch.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // CloudWatch is a client for Amazon CloudWatch.
 type CloudWatch struct {
 	client *aws.QueryClient
@@ -471,3 +476,6 @@ type ListMetricsResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/elasticache/elasticache.go
+++ b/gen/elasticache/elasticache.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // ElasticCache is a client for Amazon ElastiCache.
 type ElasticCache struct {
 	client *aws.QueryClient
@@ -1243,3 +1248,6 @@ type ResetCacheParameterGroupResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/elasticbeanstalk/elasticbeanstalk.go
+++ b/gen/elasticbeanstalk/elasticbeanstalk.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // ElasticBeanstalk is a client for AWS Elastic Beanstalk.
 type ElasticBeanstalk struct {
 	client *aws.QueryClient
@@ -1006,3 +1011,6 @@ type ValidateConfigurationSettingsResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/elb/elb.go
+++ b/gen/elb/elb.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // ELB is a client for Elastic Load Balancing.
 type ELB struct {
 	client *aws.QueryClient
@@ -1027,3 +1032,6 @@ type SetLoadBalancerPoliciesOfListenerResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/importexport/importexport.go
+++ b/gen/importexport/importexport.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // ImportExport is a client for AWS Import/Export.
 type ImportExport struct {
 	client *aws.QueryClient
@@ -233,3 +238,6 @@ type UpdateJobResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/rds/rds.go
+++ b/gen/rds/rds.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // RDS is a client for Amazon Relational Database Service.
 type RDS struct {
 	client *aws.QueryClient
@@ -1841,3 +1846,6 @@ type ResetDBParameterGroupResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/redshift/redshift.go
+++ b/gen/redshift/redshift.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // RedShift is a client for Amazon Redshift.
 type RedShift struct {
 	client *aws.QueryClient
@@ -1954,3 +1959,6 @@ type ResetClusterParameterGroupResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/sdb/sdb.go
+++ b/gen/sdb/sdb.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // SDB is a client for Amazon SimpleDB.
 type SDB struct {
 	client *aws.QueryClient
@@ -337,3 +342,6 @@ type UpdateCondition struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/ses/ses.go
+++ b/gen/ses/ses.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // SES is a client for Amazon Simple Email Service.
 type SES struct {
 	client *aws.QueryClient
@@ -304,6 +309,30 @@ type Destination struct {
 	ToAddresses  []string `query:"ToAddresses.member" xml:"ToAddresses>member"`
 }
 
+type DkimAttributes map[string]IdentityDkimAttributes
+
+// UnmarshalXML implements xml.UnmarshalXML interface for map
+func (m *DkimAttributes) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	if *m == nil {
+		(*m) = make(DkimAttributes)
+	}
+	for {
+		var e struct {
+			Key   string                 `xml:"key"`
+			Value IdentityDkimAttributes `xml:"value"`
+		}
+		err := d.DecodeElement(&e, &start)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if err == io.EOF {
+			break
+		}
+		(*m)[e.Key] = e.Value
+	}
+	return nil
+}
+
 // GetIdentityDkimAttributesRequest is undocumented.
 type GetIdentityDkimAttributesRequest struct {
 	Identities []string `query:"Identities.member" xml:"Identities>member"`
@@ -311,7 +340,7 @@ type GetIdentityDkimAttributesRequest struct {
 
 // GetIdentityDkimAttributesResponse is undocumented.
 type GetIdentityDkimAttributesResponse struct {
-	DkimAttributes map[string]IdentityDkimAttributes `query:"DkimAttributes" xml:"GetIdentityDkimAttributesResult>DkimAttributes"`
+	DkimAttributes DkimAttributes `query:"DkimAttributes.entry" xml:"GetIdentityDkimAttributesResult>DkimAttributes>entry"`
 }
 
 // GetIdentityNotificationAttributesRequest is undocumented.
@@ -321,7 +350,7 @@ type GetIdentityNotificationAttributesRequest struct {
 
 // GetIdentityNotificationAttributesResponse is undocumented.
 type GetIdentityNotificationAttributesResponse struct {
-	NotificationAttributes map[string]IdentityNotificationAttributes `query:"NotificationAttributes" xml:"GetIdentityNotificationAttributesResult>NotificationAttributes"`
+	NotificationAttributes NotificationAttributes `query:"NotificationAttributes.entry" xml:"GetIdentityNotificationAttributesResult>NotificationAttributes>entry"`
 }
 
 // GetIdentityVerificationAttributesRequest is undocumented.
@@ -331,7 +360,7 @@ type GetIdentityVerificationAttributesRequest struct {
 
 // GetIdentityVerificationAttributesResponse is undocumented.
 type GetIdentityVerificationAttributesResponse struct {
-	VerificationAttributes map[string]IdentityVerificationAttributes `query:"VerificationAttributes" xml:"GetIdentityVerificationAttributesResult>VerificationAttributes"`
+	VerificationAttributes VerificationAttributes `query:"VerificationAttributes.entry" xml:"GetIdentityVerificationAttributesResult>VerificationAttributes>entry"`
 }
 
 // GetSendQuotaResponse is undocumented.
@@ -395,6 +424,30 @@ type ListVerifiedEmailAddressesResponse struct {
 type Message struct {
 	Body    *Body    `query:"Body" xml:"Body"`
 	Subject *Content `query:"Subject" xml:"Subject"`
+}
+
+type NotificationAttributes map[string]IdentityNotificationAttributes
+
+// UnmarshalXML implements xml.UnmarshalXML interface for map
+func (m *NotificationAttributes) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	if *m == nil {
+		(*m) = make(NotificationAttributes)
+	}
+	for {
+		var e struct {
+			Key   string                         `xml:"key"`
+			Value IdentityNotificationAttributes `xml:"value"`
+		}
+		err := d.DecodeElement(&e, &start)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if err == io.EOF {
+			break
+		}
+		(*m)[e.Key] = e.Value
+	}
+	return nil
 }
 
 // Possible values for SES.
@@ -475,6 +528,30 @@ type SetIdentityNotificationTopicRequest struct {
 type SetIdentityNotificationTopicResponse struct {
 }
 
+type VerificationAttributes map[string]IdentityVerificationAttributes
+
+// UnmarshalXML implements xml.UnmarshalXML interface for map
+func (m *VerificationAttributes) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	if *m == nil {
+		(*m) = make(VerificationAttributes)
+	}
+	for {
+		var e struct {
+			Key   string                         `xml:"key"`
+			Value IdentityVerificationAttributes `xml:"value"`
+		}
+		err := d.DecodeElement(&e, &start)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if err == io.EOF {
+			break
+		}
+		(*m)[e.Key] = e.Value
+	}
+	return nil
+}
+
 // Possible values for SES.
 const (
 	VerificationStatusFailed           = "Failed"
@@ -524,17 +601,17 @@ type DeleteIdentityResult struct {
 
 // GetIdentityDkimAttributesResult is a wrapper for GetIdentityDkimAttributesResponse.
 type GetIdentityDkimAttributesResult struct {
-	DkimAttributes map[string]IdentityDkimAttributes `query:"DkimAttributes" xml:"GetIdentityDkimAttributesResult>DkimAttributes"`
+	DkimAttributes DkimAttributes `query:"DkimAttributes.entry" xml:"GetIdentityDkimAttributesResult>DkimAttributes>entry"`
 }
 
 // GetIdentityNotificationAttributesResult is a wrapper for GetIdentityNotificationAttributesResponse.
 type GetIdentityNotificationAttributesResult struct {
-	NotificationAttributes map[string]IdentityNotificationAttributes `query:"NotificationAttributes" xml:"GetIdentityNotificationAttributesResult>NotificationAttributes"`
+	NotificationAttributes NotificationAttributes `query:"NotificationAttributes.entry" xml:"GetIdentityNotificationAttributesResult>NotificationAttributes>entry"`
 }
 
 // GetIdentityVerificationAttributesResult is a wrapper for GetIdentityVerificationAttributesResponse.
 type GetIdentityVerificationAttributesResult struct {
-	VerificationAttributes map[string]IdentityVerificationAttributes `query:"VerificationAttributes" xml:"GetIdentityVerificationAttributesResult>VerificationAttributes"`
+	VerificationAttributes VerificationAttributes `query:"VerificationAttributes.entry" xml:"GetIdentityVerificationAttributesResult>VerificationAttributes>entry"`
 }
 
 // GetSendQuotaResult is a wrapper for GetSendQuotaResponse.
@@ -598,3 +675,6 @@ type VerifyEmailIdentityResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/gen/sts/sts.go
+++ b/gen/sts/sts.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stripe/aws-go/gen/endpoints"
 )
 
+import (
+	"encoding/xml"
+	"io"
+)
+
 // STS is a client for AWS Security Token Service.
 type STS struct {
 	client *aws.QueryClient
@@ -470,3 +475,6 @@ type GetSessionTokenResult struct {
 
 // avoid errors if the packages aren't referenced
 var _ time.Time
+
+var _ xml.Decoder
+var _ = io.EOF

--- a/internal/unmarshal_xml_test.go
+++ b/internal/unmarshal_xml_test.go
@@ -1,0 +1,168 @@
+package internal
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+
+	"github.com/stripe/aws-go/aws"
+	"github.com/stripe/aws-go/gen/iam"
+	"github.com/stripe/aws-go/gen/sqs"
+)
+
+func Test_SQSUnmarshalXML(t *testing.T) {
+	var actualXML = []byte(`
+<?xml version="1.0"?>
+<ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">
+  <ReceiveMessageResult>
+    <Message>
+      <Body>body1</Body>
+      <MD5OfBody>snip</MD5OfBody>
+      <ReceiptHandle>snip</ReceiptHandle>
+      <Attribute>
+        <Name>SenderId</Name>
+        <Value>snip</Value>
+      </Attribute>
+      <Attribute>
+        <Name>ApproximateFirstReceiveTimestamp</Name>
+        <Value>1420089460638</Value>
+      </Attribute>
+      <MessageAttribute>
+        <Name>ATTR1</Name>
+        <Value>
+          <DataType>String</DataType>
+          <StringValue>STRING!!</StringValue>
+        </Value>
+      </MessageAttribute>
+      <MessageAttribute>
+        <Name>ATTR2</Name>
+        <Value>
+          <DataType>Number</DataType>
+          <StringValue>12345</StringValue>
+        </Value>
+      </MessageAttribute>
+      <MessageId>snip</MessageId>
+      <MD5OfMessageAttributes>snip</MD5OfMessageAttributes>
+    </Message>
+    <Message>
+      <Body>body2</Body>
+      <MD5OfBody>snip</MD5OfBody>
+      <ReceiptHandle>snip</ReceiptHandle>
+      <Attribute>
+        <Name>SenderId</Name>
+        <Value>snip</Value>
+      </Attribute>
+      <Attribute>
+        <Name>ApproximateFirstReceiveTimestamp</Name>
+        <Value>1420089460638</Value>
+      </Attribute>
+      <MessageAttribute>
+        <Name>ATTR1</Name>
+        <Value>
+          <DataType>String</DataType>
+          <StringValue>STRING!!</StringValue>
+        </Value>
+      </MessageAttribute>
+      <MessageAttribute>
+        <Name>ATTR2</Name>
+        <Value>
+          <DataType>Number</DataType>
+          <StringValue>12345</StringValue>
+        </Value>
+      </MessageAttribute>
+      <MessageId>snip</MessageId>
+      <MD5OfMessageAttributes>snip</MD5OfMessageAttributes>
+    </Message>
+  </ReceiveMessageResult>
+  <ResponseMetadata>
+    <RequestId>snip</RequestId>
+  </ResponseMetadata>
+</ReceiveMessageResponse>`)
+
+	expectedMessageAttributes := sqs.MessageAttributeMap{
+		"ATTR1": sqs.MessageAttributeValue{
+			DataType:    aws.String("String"),
+			StringValue: aws.String("STRING!!"),
+		},
+		"ATTR2": sqs.MessageAttributeValue{
+			DataType:    aws.String("Number"),
+			StringValue: aws.String("12345"),
+		},
+	}
+
+	expectedAttributes := sqs.AttributeMap{
+		"SenderId":                         "snip",
+		"ApproximateFirstReceiveTimestamp": "1420089460638",
+	}
+
+	expectedString := aws.String("snip")
+
+	expected := &sqs.ReceiveMessageResult{
+		Messages: []sqs.Message{
+			sqs.Message{
+				Attributes:             expectedAttributes,
+				Body:                   aws.String("body1"),
+				MD5OfBody:              expectedString,
+				MD5OfMessageAttributes: expectedString,
+				MessageAttributes:      expectedMessageAttributes,
+				MessageID:              expectedString,
+				ReceiptHandle:          expectedString,
+			},
+			sqs.Message{
+				Attributes:             expectedAttributes,
+				Body:                   aws.String("body2"),
+				MD5OfBody:              expectedString,
+				MD5OfMessageAttributes: expectedString,
+				MessageAttributes:      expectedMessageAttributes,
+				MessageID:              expectedString,
+				ReceiptHandle:          expectedString,
+			},
+		},
+	}
+
+	actual := &sqs.ReceiveMessageResult{}
+	if err := xml.Unmarshal(actualXML, actual); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Got \n%v\n but expected \n%v", actual, expected)
+	}
+}
+
+func Test_IAMUnmarshal(t *testing.T) {
+	actualXML := []byte(`
+<GetAccountSummaryResponse>
+<GetAccountSummaryResult>
+  <SummaryMap>
+    <entry>
+      <key>Groups</key>
+      <value>31</value>
+    </entry>
+    <entry>
+      <key>GroupsQuota</key>
+      <value>50</value>
+    </entry>
+  </SummaryMap>
+</GetAccountSummaryResult>
+<ResponseMetadata>
+  <RequestId>f1e38443-f1ad-11df-b1ef-a9265EXAMPLE</RequestId>
+</ResponseMetadata>
+</GetAccountSummaryResponse>`)
+
+	expected := &iam.GetAccountSummaryResponse{
+		SummaryMap: iam.SummaryMapType{
+			"Groups":      31,
+			"GroupsQuota": 50,
+		},
+	}
+
+	actual := &iam.GetAccountSummaryResponse{}
+	if err := xml.Unmarshal(actualXML, actual); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Got \n%v\n but expected \n%v", actual, expected)
+	}
+}


### PR DESCRIPTION
As you may know, XML does not handle map well like JSON does because we don't know what element value will be used as a key or as a value.

We need to implement xml.Unmarshaler interface for map.

In this PR, UnmarshalXML is generated only for query protocol because I have no idea how to detect which format is used in response.

Once this PR lands, SQS's ReceiveMessage works well with MessageAttributes:clap: